### PR TITLE
fix(#1): remove type from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "halo-infinite-api",
-  "type": "module",
   "version": "9.0.1",
   "description": "An NPM package for accessing the official Halo Infinite API.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Context

This PR fixes #1 

In a consuming application where it has been configured with `"type": "module",` in the `package.json` file, and the application uses typescript module files (i.e. `.mts`), Typescript server is unable to detect types for this package, even though they are being produced.

Whilst I have no concrete reasoning, I believe it is because the output of the build is that of a standard package with cjs type output rather than mjs.

Digging into it further, Typescript has a few issues commenting on this and possible work arounds such as duplicating the output and simply renaming them, but it probably isn't worth going into.

## How has this been tested

In my consuming application, I used [`patch-package`](https://www.npmjs.com/package/patch-package) with the following patch file for this package...

```
diff --git a/node_modules/halo-infinite-api/package.json b/node_modules/halo-infinite-api/package.json
index cb8f32b..59302db 100644
--- a/node_modules/halo-infinite-api/package.json
+++ b/node_modules/halo-infinite-api/package.json
@@ -1,6 +1,5 @@
 {
   "name": "halo-infinite-api",
-  "type": "module",
   "version": "9.0.1",
   "description": "An NPM package for accessing the official Halo Infinite API.",
   "main": "dist/index.js",
```

And I was able to successfully get types.

![image](https://github.com/user-attachments/assets/f1e762b9-a328-4f5f-af91-84ae1aa0502e)
