### PR TITLE
Add endpoint to get player match count

### DIFF
--- a/src/core/halo-infinite-client.ts
+++ b/src/core/halo-infinite-client.ts
@@ -31,6 +31,7 @@ import { DateTime } from "luxon";
 import { wrapPlayerId, unwrapPlayerId } from "../util/xuid";
 import { SeasonCalendarContainer } from "../models/halo-infinite/season";
 import { Settings } from "../models/halo-infinite/settings";
+import { MatchCount } from "src/models/halo-infinite/match-count";
 
 export interface ResultContainer<TValue> {
   Id: string;
@@ -330,6 +331,18 @@ export class HaloInfiniteClient {
       }
     );
   };
+
+  public getPlayerMatchCount = (
+    playerXuid: string,
+    init?: Omit<RequestInit, "body" | "method">
+  ) =>
+    this.executeJsonRequest<MatchCount>(
+      `https://${HaloCoreEndpoints.StatsOrigin}.${HaloCoreEndpoints.ServiceDomain}/hi/players/${wrapPlayerId(playerXuid)}/matches/count`,
+      {
+        ...init,
+        method: "get",
+      }
+    );
 
   public getMatchStats = (
     matchId: string,

--- a/src/models/halo-infinite/match-count.ts
+++ b/src/models/halo-infinite/match-count.ts
@@ -1,0 +1,6 @@
+export interface MatchCount {
+  "CustomMatchesPlayedCount": number;
+  "MatchesPlayedCount": number;
+  "MatchmadeMatchesPlayedCount": number;
+  "LocalMatchesPlayedCount": number;
+}


### PR DESCRIPTION
I'd like to add `https://halostats.svc.halowaypoint.com/hi/players/xuid(<xuid>)/matches/count` which allows me to get the custom game count.

i've tested this locally and it works with the following response

```
{
  "CustomMatchesPlayedCount": 3730,
  "MatchesPlayedCount": 12641,
  "MatchmadeMatchesPlayedCount": 8911,
  "LocalMatchesPlayedCount": 0
}
```